### PR TITLE
Count to 0 if no rows in sql

### DIFF
--- a/filecoverage/FCReporter.cfc
+++ b/filecoverage/FCReporter.cfc
@@ -99,9 +99,12 @@ component {
 
 
 
-		var count = raw.reduce(function(hits=0,cols,index,query){
-			return hits + cols.count;
-		});
+		var count = 0;
+		if (raw.recordCount) {
+			count = raw.reduce(function(hits=0,cols,index,query){
+				return hits + cols.count;
+			});			
+		}
 
 		
 		


### PR DESCRIPTION
When a file has no use, and you try to open in info.cfm, count is null and throws an exception